### PR TITLE
don't throw fatal, as we want pass return error

### DIFF
--- a/SQL2/sql2.go
+++ b/SQL2/sql2.go
@@ -203,13 +203,13 @@ func connopen(cnstr string) (*sql.DB, context.Context, error) {
 	db, err := sql.Open("sqlserver", cnstr)
 
 	if err != nil {
-		log.Fatal("Błąd sterownika: ", err.Error())
+		log.Println("Błąd sterownika: ", err.Error())
 	}
 	ctx := context.Background()
 	err = db.PingContext(ctx)
 
 	if err != nil {
-		log.Fatal("Problem puli połączenia: ", err.Error())
+		log.Println("Problem puli połączenia: ", err.Error())
 	}
 
 	return db, ctx, err


### PR DESCRIPTION
We don't want to throw fatal and exit the program, as we want to return error in exit code and handle it in later